### PR TITLE
Feat/REPGRANT-618 Update CHEFS form configuration for multi-step forms

### DIFF
--- a/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
+++ b/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
@@ -15,7 +15,9 @@ public class ChefsApiKeyHandlerTests
 
     [Theory]
     [InlineData("/api/v1/forms/11111111-1111-1111-1111-111111111111/submissions")]
+    [InlineData("/app/api/v1/forms/11111111-1111-1111-1111-111111111111/submissions")]
     [InlineData("/gateway/v1/auth/token/forms/11111111-1111-1111-1111-111111111111")]
+    [InlineData("/app/gateway/v1/auth/token/forms/11111111-1111-1111-1111-111111111111")]
     public async Task SendAsync_WithConfiguredForm_AddsBasicAuthorization(string path)
     {
         var captureHandler = new CaptureHandler();

--- a/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
+++ b/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
@@ -135,7 +135,10 @@ public class ChefsApiKeyHandlerTests
         )
         {
             Request = request;
+#pragma warning disable CA2000
+            // Dummy response is handled by the invoker, so we don't need to dispose it here.
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+#pragma warning restore CA2000
         }
     }
 }

--- a/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
+++ b/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
@@ -96,6 +96,22 @@ public class ChefsApiKeyHandlerTests
         Assert.Contains("No form configuration found", exception.Message);
     }
 
+    [Fact]
+    public async Task SendAsync_WithUnapprovedPath_ThrowsClearException()
+    {
+        using var invoker = CreateInvoker(new CaptureHandler());
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://chefs.example.com/app/admin/forms/{LegalFormId}/submissions"
+        );
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            invoker.SendAsync(request, CancellationToken.None)
+        );
+
+        Assert.Contains("not an approved CHEFS form endpoint", exception.Message);
+    }
+
     private static HttpMessageInvoker CreateInvoker(
         HttpMessageHandler innerHandler,
         ChefsOptions? options = null

--- a/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
+++ b/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
@@ -20,9 +20,12 @@ public class ChefsApiKeyHandlerTests
     {
         var captureHandler = new CaptureHandler();
         using var invoker = CreateInvoker(captureHandler);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"https://chefs.example.com{path}");
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://chefs.example.com{path}"
+        );
 
-        await invoker.SendAsync(request, CancellationToken.None);
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
 
         Assert.NotNull(captureHandler.Request);
         Assert.Equal("Basic", captureHandler.Request.Headers.Authorization?.Scheme);
@@ -37,12 +40,12 @@ public class ChefsApiKeyHandlerTests
     {
         var captureHandler = new CaptureHandler();
         using var invoker = CreateInvoker(captureHandler);
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Delete,
             $"https://chefs.example.com/api/v1/forms/{NonLegalFormId}/submissions/submission-id"
         );
 
-        await invoker.SendAsync(request, CancellationToken.None);
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
 
         Assert.Equal(
             Convert.ToBase64String(Encoding.UTF8.GetBytes($"{NonLegalFormId}:nonlegal-api-key")),
@@ -63,7 +66,7 @@ public class ChefsApiKeyHandlerTests
                 },
             }
         );
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get,
             $"https://chefs.example.com/api/v1/forms/{LegalFormId}/submissions"
         );
@@ -79,7 +82,7 @@ public class ChefsApiKeyHandlerTests
     public async Task SendAsync_WithUnconfiguredForm_ThrowsClearException()
     {
         using var invoker = CreateInvoker(new CaptureHandler());
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get,
             "https://chefs.example.com/api/v1/forms/33333333-3333-3333-3333-333333333333/submissions"
         );

--- a/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
+++ b/api.tests/Infrastructure/ChefsApiKeyHandlerTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Probate.Api.Infrastructure.Chefs;
+using Probate.Api.Options;
+
+namespace Probate.Api.Tests.Infrastructure;
+
+public class ChefsApiKeyHandlerTests
+{
+    private const string LegalFormId = "11111111-1111-1111-1111-111111111111";
+    private const string LegalApiKey = "legal-api-key";
+    private const string NonLegalFormId = "22222222-2222-2222-2222-222222222222";
+
+    [Theory]
+    [InlineData("/api/v1/forms/11111111-1111-1111-1111-111111111111/submissions")]
+    [InlineData("/gateway/v1/auth/token/forms/11111111-1111-1111-1111-111111111111")]
+    public async Task SendAsync_WithConfiguredForm_AddsBasicAuthorization(string path)
+    {
+        var captureHandler = new CaptureHandler();
+        using var invoker = CreateInvoker(captureHandler);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"https://chefs.example.com{path}");
+
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        Assert.NotNull(captureHandler.Request);
+        Assert.Equal("Basic", captureHandler.Request.Headers.Authorization?.Scheme);
+        Assert.Equal(
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{LegalFormId}:{LegalApiKey}")),
+            captureHandler.Request.Headers.Authorization?.Parameter
+        );
+    }
+
+    [Fact]
+    public async Task SendAsync_WithDifferentConfiguredForm_UsesMatchingApiKey()
+    {
+        var captureHandler = new CaptureHandler();
+        using var invoker = CreateInvoker(captureHandler);
+        var request = new HttpRequestMessage(
+            HttpMethod.Delete,
+            $"https://chefs.example.com/api/v1/forms/{NonLegalFormId}/submissions/submission-id"
+        );
+
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        Assert.Equal(
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{NonLegalFormId}:nonlegal-api-key")),
+            captureHandler.Request?.Headers.Authorization?.Parameter
+        );
+    }
+
+    [Fact]
+    public async Task SendAsync_WithBlankApiKey_ThrowsClearException()
+    {
+        using var invoker = CreateInvoker(
+            new CaptureHandler(),
+            new ChefsOptions
+            {
+                Forms =
+                {
+                    ["legal"] = new ChefsFormOptions { FormId = LegalFormId, ApiKey = " " },
+                },
+            }
+        );
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://chefs.example.com/api/v1/forms/{LegalFormId}/submissions"
+        );
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            invoker.SendAsync(request, CancellationToken.None)
+        );
+
+        Assert.Contains("API key is not configured", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithUnconfiguredForm_ThrowsClearException()
+    {
+        using var invoker = CreateInvoker(new CaptureHandler());
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "https://chefs.example.com/api/v1/forms/33333333-3333-3333-3333-333333333333/submissions"
+        );
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            invoker.SendAsync(request, CancellationToken.None)
+        );
+
+        Assert.Contains("No form configuration found", exception.Message);
+    }
+
+    private static HttpMessageInvoker CreateInvoker(
+        HttpMessageHandler innerHandler,
+        ChefsOptions? options = null
+    )
+    {
+        var handler = new ChefsApiKeyHandler(
+            Microsoft.Extensions.Options.Options.Create(options ?? CreateOptions())
+        )
+        {
+            InnerHandler = innerHandler,
+        };
+
+        return new HttpMessageInvoker(handler);
+    }
+
+    private static ChefsOptions CreateOptions()
+    {
+        return new ChefsOptions
+        {
+            Forms =
+            {
+                ["legal"] = new ChefsFormOptions { FormId = LegalFormId, ApiKey = LegalApiKey },
+                ["nonlegal"] = new ChefsFormOptions
+                {
+                    FormId = NonLegalFormId,
+                    ApiKey = "nonlegal-api-key",
+                },
+            },
+        };
+    }
+
+    private sealed class CaptureHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Request = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/api.tests/Infrastructure/ChefsServiceCollectionExtensionsTests.cs
+++ b/api.tests/Infrastructure/ChefsServiceCollectionExtensionsTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Probate.Api.Helpers.Exceptions;
+using Probate.Api.Infrastructure.Chefs;
+
+namespace Probate.Api.Tests.Infrastructure;
+
+public class ChefsServiceCollectionExtensionsTests
+{
+    private const string LegalFormId = "11111111-1111-1111-1111-111111111111";
+
+    [Fact]
+    public void AddChefsApi_RegistersChefsApiWithValidConfiguration()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration();
+
+        services.AddChefsApi(configuration);
+        var serviceProvider = services.BuildServiceProvider();
+
+        Assert.NotNull(serviceProvider.GetService<IChefsApi>());
+        Assert.NotNull(serviceProvider.GetService<ChefsApiKeyHandler>());
+    }
+
+    [Fact]
+    public void AddChefsApi_ThrowsWhenFormsMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Chefs:BaseUrl"] = "https://chefs.example.com/app",
+            }
+        );
+
+        var exception = Assert.Throws<ConfigurationException>(() =>
+            services.AddChefsApi(configuration)
+        );
+
+        Assert.Contains("Chefs:Forms", exception.Message);
+    }
+
+    [Fact]
+    public void AddChefsApi_ThrowsWhenFormKeyBlank()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Chefs:BaseUrl"] = "https://chefs.example.com/app",
+                ["Chefs:Forms: :FormId"] = LegalFormId,
+                ["Chefs:Forms: :ApiKey"] = "legal-api-key",
+            }
+        );
+
+        var exception = Assert.Throws<ConfigurationException>(() =>
+            services.AddChefsApi(configuration)
+        );
+
+        Assert.Contains("non-empty logical key", exception.Message);
+    }
+
+    [Fact]
+    public void AddChefsApi_ThrowsWhenFormIdMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Chefs:BaseUrl"] = "https://chefs.example.com/app",
+                ["Chefs:Forms:legal:FormId"] = "",
+                ["Chefs:Forms:legal:ApiKey"] = "legal-api-key",
+            }
+        );
+
+        var exception = Assert.Throws<ConfigurationException>(() =>
+            services.AddChefsApi(configuration)
+        );
+
+        Assert.Contains("Chefs:Forms:legal:FormId", exception.Message);
+        Assert.Contains("Chefs__Forms__legal__FormId", exception.Message);
+    }
+
+    [Fact]
+    public void AddChefsApi_ThrowsWhenApiKeyMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Chefs:BaseUrl"] = "https://chefs.example.com/app",
+                ["Chefs:Forms:legal:FormId"] = LegalFormId,
+                ["Chefs:Forms:legal:ApiKey"] = " ",
+            }
+        );
+
+        var exception = Assert.Throws<ConfigurationException>(() =>
+            services.AddChefsApi(configuration)
+        );
+
+        Assert.Contains("Chefs:Forms:legal:ApiKey", exception.Message);
+        Assert.Contains("Chefs__Forms__legal__ApiKey", exception.Message);
+    }
+
+    private static IConfiguration BuildConfiguration(
+        Dictionary<string, string?>? overrides = null
+    )
+    {
+        var configData =
+            overrides
+            ?? new Dictionary<string, string?>
+            {
+                ["Chefs:BaseUrl"] = "https://chefs.example.com/app",
+                ["Chefs:Forms:legal:FormId"] = LegalFormId,
+                ["Chefs:Forms:legal:ApiKey"] = "legal-api-key",
+            };
+
+        return new ConfigurationBuilder().AddInMemoryCollection(configData).Build();
+    }
+}

--- a/api.tests/Integration/ChefsAuthTokenIntegrationTests.cs
+++ b/api.tests/Integration/ChefsAuthTokenIntegrationTests.cs
@@ -66,8 +66,8 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
     {
         // Arrange
         var formKey = "legal";
-        var legalFormOptions = _chefsOptions.Forms.ContainsKey(formKey)
-            ? _chefsOptions.Forms[formKey]
+        var legalFormOptions = _chefsOptions.Forms.TryGetValue(formKey, out var options)
+            ? options
             : null;
         // Skip test if form key is not configured
         if (legalFormOptions == null || string.IsNullOrWhiteSpace(legalFormOptions.FormId))
@@ -134,9 +134,9 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
 
         // Skip test if form key is not configured
         if (
-            !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
+            !_chefsOptions.Forms.TryGetValue(formKey, out var formOptions)
+            || string.IsNullOrWhiteSpace(formOptions.FormId)
+            || string.IsNullOrWhiteSpace(formOptions.ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");
@@ -154,7 +154,7 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         Assert.NotEmpty(result1.Token);
         Assert.NotEmpty(result2.Token);
         Assert.Equal(result1.FormId, result2.FormId); // Same form ID
-        Assert.Equal(_chefsOptions.Forms[formKey].FormId, result1.FormId);
+        Assert.Equal(formOptions.FormId, result1.FormId);
 
         _output.WriteLine(
             $"Token 1 (first 30 chars): {result1.Token.Substring(0, Math.Min(30, result1.Token.Length))}..."
@@ -180,9 +180,9 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
 
         // Skip test if form key is not configured
         if (
-            !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
+            !_chefsOptions.Forms.TryGetValue(formKey, out var formOptions)
+            || string.IsNullOrWhiteSpace(formOptions.FormId)
+            || string.IsNullOrWhiteSpace(formOptions.ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");
@@ -227,9 +227,9 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
 
         // Skip test if form key is not configured
         if (
-            !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
+            !_chefsOptions.Forms.TryGetValue(formKey, out var formOptions)
+            || string.IsNullOrWhiteSpace(formOptions.FormId)
+            || string.IsNullOrWhiteSpace(formOptions.ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");

--- a/api.tests/Integration/ChefsAuthTokenIntegrationTests.cs
+++ b/api.tests/Integration/ChefsAuthTokenIntegrationTests.cs
@@ -66,25 +66,24 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
     {
         // Arrange
         var formKey = "legal";
-
+        var legalFormOptions = _chefsOptions.Forms.ContainsKey(formKey)
+            ? _chefsOptions.Forms[formKey]
+            : null;
         // Skip test if form key is not configured
-        if (
-            !_chefsOptions.Forms.TryGetValue(formKey, out var formId)
-            || string.IsNullOrWhiteSpace(formId)
-        )
+        if (legalFormOptions == null || string.IsNullOrWhiteSpace(legalFormOptions.FormId))
         {
             _output.WriteLine($"Skipping test: Form key '{formKey}' is not configured.");
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(_chefsOptions.ApiKey))
+        if (string.IsNullOrWhiteSpace(legalFormOptions.ApiKey))
         {
             _output.WriteLine("Skipping test: CHEFS API key is not configured.");
             return;
         }
 
         _output.WriteLine($"Testing with form key: {formKey}");
-        _output.WriteLine($"Form GUID: {formId}");
+        _output.WriteLine($"Form GUID: {legalFormOptions.FormId}");
         _output.WriteLine($"Base URL: {_chefsOptions.BaseUrl}");
 
         // Act
@@ -96,7 +95,7 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         Assert.NotEmpty(result.Token);
         Assert.NotNull(result.FormId);
         Assert.NotEmpty(result.FormId);
-        Assert.Equal(formId, result.FormId);
+        Assert.Equal(legalFormOptions.FormId, result.FormId);
 
         _output.WriteLine(
             $"Token received (first 50 chars): {result.Token.Substring(0, Math.Min(50, result.Token.Length))}..."
@@ -136,8 +135,8 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         // Skip test if form key is not configured
         if (
             !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey])
-            || string.IsNullOrWhiteSpace(_chefsOptions.ApiKey)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");
@@ -155,7 +154,7 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         Assert.NotEmpty(result1.Token);
         Assert.NotEmpty(result2.Token);
         Assert.Equal(result1.FormId, result2.FormId); // Same form ID
-        Assert.Equal(_chefsOptions.Forms[formKey], result1.FormId);
+        Assert.Equal(_chefsOptions.Forms[formKey].FormId, result1.FormId);
 
         _output.WriteLine(
             $"Token 1 (first 30 chars): {result1.Token.Substring(0, Math.Min(30, result1.Token.Length))}..."
@@ -182,8 +181,8 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         // Skip test if form key is not configured
         if (
             !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey])
-            || string.IsNullOrWhiteSpace(_chefsOptions.ApiKey)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");
@@ -229,8 +228,8 @@ public class ChefsAuthTokenIntegrationTests : IDisposable
         // Skip test if form key is not configured
         if (
             !_chefsOptions.Forms.ContainsKey(formKey)
-            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey])
-            || string.IsNullOrWhiteSpace(_chefsOptions.ApiKey)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].FormId)
+            || string.IsNullOrWhiteSpace(_chefsOptions.Forms[formKey].ApiKey)
         )
         {
             _output.WriteLine("Skipping test: Configuration not available.");

--- a/api.tests/Services/ChefsApplicationServiceTests.cs
+++ b/api.tests/Services/ChefsApplicationServiceTests.cs
@@ -29,10 +29,24 @@ public class ChefsApplicationServiceTests
         _mockLogger = new Mock<ILogger<ChefsApplicationService>>();
         _chefsOptions = new ChefsOptions
         {
-            Forms = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            Forms = new Dictionary<string, ChefsFormOptions>(StringComparer.OrdinalIgnoreCase)
             {
-                { "legal", "12345678-1234-1234-1234-123456789012" },
-                { "probate", "87654321-4321-4321-4321-210987654321" },
+                {
+                    "legal",
+                    new ChefsFormOptions
+                    {
+                        FormId = "12345678-1234-1234-1234-123456789012",
+                        ApiKey = "legal-api-key",
+                    }
+                },
+                {
+                    "probate",
+                    new ChefsFormOptions
+                    {
+                        FormId = "87654321-4321-4321-4321-210987654321",
+                        ApiKey = "probate-api-key",
+                    }
+                },
             },
         };
 

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -48,12 +48,17 @@ public class ChefsApiKeyHandler : DelegatingHandler
 
         // Reverse lookup: the path contains the CHEFS GUID; Forms is keyed by logical name.
         var formOptions = _options.Forms.Values.FirstOrDefault(f =>
-            f.FormId.Equals(formId, StringComparison.OrdinalIgnoreCase)
+            string.Equals(f.FormId, formId, StringComparison.OrdinalIgnoreCase)
         );
 
         if (formOptions is null)
             throw new InvalidOperationException(
                 $"[CHEFS] No form configuration found for formId '{formId}'. Check Chefs:Forms in configuration."
+            );
+
+        if (string.IsNullOrWhiteSpace(formOptions.ApiKey))
+            throw new InvalidOperationException(
+                $"[CHEFS] API key is not configured for formId '{formId}'. Check Chefs:Forms configuration."
             );
 
         var authValue = Convert.ToBase64String(

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -19,7 +19,7 @@ namespace Probate.Api.Infrastructure.Chefs;
 public class ChefsApiKeyHandler : DelegatingHandler
 {
     private static readonly Regex FormIdPathRegex = new(
-        @"(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
+        @"(?:/app)?(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled
     );
 

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -18,6 +18,11 @@ namespace Probate.Api.Infrastructure.Chefs;
 /// </summary>
 public class ChefsApiKeyHandler : DelegatingHandler
 {
+    private static readonly Regex FormIdPathRegex = new(
+        @"(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
     private readonly ChefsOptions _options;
 
     public ChefsApiKeyHandler(IOptions<ChefsOptions> options)
@@ -32,12 +37,7 @@ public class ChefsApiKeyHandler : DelegatingHandler
     {
         var path = request.RequestUri?.AbsolutePath ?? "";
 
-        // Matches /api/v1/forms/{formId}/... or /gateway/v1/auth/token/forms/{formId}/...
-        var formIdMatch = Regex.Match(
-            path,
-            @"(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
-            RegexOptions.IgnoreCase
-        );
+        var formIdMatch = FormIdPathRegex.Match(path);
 
         if (!formIdMatch.Success)
             throw new InvalidOperationException(

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -11,9 +12,9 @@ using Probate.Api.Options;
 namespace Probate.Api.Infrastructure.Chefs;
 
 /// <summary>
-/// Adds the CHEFS api-key header to every request. We use api-key only (auth-token is not used).
-/// form-id is sent per request by the Refit method (path + header).
-/// For auth token requests, uses Basic Authentication with formId:apiKey.
+/// Adds Basic Authentication to every CHEFS request using the per-form API key.
+/// The CHEFS form GUID is extracted from the request path and reverse-looked up
+/// against the configured form options to find the matching API key.
 /// </summary>
 public class ChefsApiKeyHandler : DelegatingHandler
 {
@@ -31,34 +32,37 @@ public class ChefsApiKeyHandler : DelegatingHandler
     {
         var path = request.RequestUri?.AbsolutePath ?? "";
 
-        // Review the IChefsApi interface to see which endpoints require formId in the path.
+        // Matches /api/v1/forms/{formId}/... or /gateway/v1/auth/token/forms/{formId}/...
         var formIdMatch = Regex.Match(
             path,
-            @"^(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
+            @"(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
             RegexOptions.IgnoreCase
         );
 
-        string? formId = formIdMatch.Success ? formIdMatch.Groups[1].Value : null;
-
-        // When the Form ID does not resolve to a API Key, we'll allow CHEFS to handle failures.
-        if (
-            !string.IsNullOrEmpty(formId) && _options.Forms.TryGetValue(formId, out var formOptions)
-        )
-        {
-            var apiKey = formOptions.ApiKey;
-            // Apply Basic Auth for dynamic formId
-            var authValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{formId}:{apiKey}"));
-            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
-
-            // Optional debug logging
-            System.Diagnostics.Debug.WriteLine(
-                $"[CHEFS] Basic Auth applied for formId={formId}, URL={request.RequestUri}"
+        if (!formIdMatch.Success)
+            throw new InvalidOperationException(
+                $"[CHEFS] Could not extract a formId from request path: {path}"
             );
-        }
+
+        var formId = formIdMatch.Groups[1].Value;
+
+        // Reverse lookup: the path contains the CHEFS GUID; Forms is keyed by logical name.
+        var formOptions = _options.Forms.Values.FirstOrDefault(f =>
+            f.FormId.Equals(formId, StringComparison.OrdinalIgnoreCase)
+        );
+
+        if (formOptions is null)
+            throw new InvalidOperationException(
+                $"[CHEFS] No form configuration found for formId '{formId}'. Check Chefs:Forms in configuration."
+            );
+
+        var authValue = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{formId}:{formOptions.ApiKey}")
+        );
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        // Optional debug logging for non-success responses
         if (!response.IsSuccessStatusCode)
         {
             var content = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -30,58 +31,29 @@ public class ChefsApiKeyHandler : DelegatingHandler
     {
         var path = request.RequestUri?.AbsolutePath ?? "";
 
-        string? formId = null;
+        // Review the IChefsApi interface to see which endpoints require formId in the path.
+        var formIdMatch = Regex.Match(
+            path,
+            @"^(?:/api/v1/forms/|/gateway/v1/auth/token/forms/)([^/]+)",
+            RegexOptions.IgnoreCase
+        );
 
-        // Submissions endpoint: /app/api/v1/forms/{formId}/submissions
-        if (path.StartsWith("/app/api/v1/forms/", StringComparison.OrdinalIgnoreCase))
-        {
-            var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            if (
-                segments.Length >= 5
-                && segments[3].Equals("forms", StringComparison.OrdinalIgnoreCase)
-            )
-            {
-                formId = segments[4];
-            }
-        }
-        // Auth token endpoint: app/gateway/v1/auth/token/forms/{formId}
-        else if (
-            path.StartsWith("/app/gateway/v1/auth/token/forms/", StringComparison.OrdinalIgnoreCase)
+        string? formId = formIdMatch.Success ? formIdMatch.Groups[1].Value : null;
+
+        // When the Form ID does not resolve to a API Key, we'll allow CHEFS to handle failures.
+        if (
+            !string.IsNullOrEmpty(formId) && _options.Forms.TryGetValue(formId, out var formOptions)
         )
         {
-            var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            if (
-                segments.Length >= 7
-                && segments[5].Equals("forms", StringComparison.OrdinalIgnoreCase)
-            )
-            {
-                formId = segments[6];
-            }
-        }
-
-        if (!string.IsNullOrEmpty(formId) && !string.IsNullOrEmpty(_options.ApiKey))
-        {
+            var apiKey = formOptions.ApiKey;
             // Apply Basic Auth for dynamic formId
-            var authValue = Convert.ToBase64String(
-                Encoding.UTF8.GetBytes($"{formId}:{_options.ApiKey}")
-            );
+            var authValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{formId}:{apiKey}"));
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
 
             // Optional debug logging
             System.Diagnostics.Debug.WriteLine(
                 $"[CHEFS] Basic Auth applied for formId={formId}, URL={request.RequestUri}"
             );
-        }
-        else
-        {
-            // Fallback: apply API key header for other requests
-            if (!string.IsNullOrEmpty(_options.ApiKey))
-            {
-                request.Headers.TryAddWithoutValidation("api-key", _options.ApiKey);
-                System.Diagnostics.Debug.WriteLine(
-                    $"[CHEFS] API Key header applied, URL={request.RequestUri}"
-                );
-            }
         }
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
+++ b/api/Infrastructure/Chefs/ChefsApiKeyHandler.cs
@@ -13,8 +13,9 @@ namespace Probate.Api.Infrastructure.Chefs;
 
 /// <summary>
 /// Adds Basic Authentication to every CHEFS request using the per-form API key.
-/// The CHEFS form GUID is extracted from the request path and reverse-looked up
-/// against the configured form options to find the matching API key.
+/// Credentials are attached only for approved CHEFS form API and gateway paths.
+/// The CHEFS form GUID is extracted from approved request paths and reverse-looked
+/// up against the configured form options to find the matching API key.
 /// </summary>
 public class ChefsApiKeyHandler : DelegatingHandler
 {
@@ -35,13 +36,19 @@ public class ChefsApiKeyHandler : DelegatingHandler
         CancellationToken cancellationToken
     )
     {
+        // Refit route templates must start with '/', which makes them absolute-path references.
+        // When combined with a BaseAddress that has a path segment (e.g. ".../app"), the '/app'
+        // segment is dropped by Uri resolution. Re-apply the configured base path here so requests
+        // hit ".../app/api/v1/..." instead of ".../api/v1/..." (which returns SPA HTML, not JSON).
+        request.RequestUri = ApplyBasePath(request.RequestUri);
+
         var path = request.RequestUri?.AbsolutePath ?? "";
 
         var formIdMatch = FormIdPathRegex.Match(path);
 
         if (!formIdMatch.Success)
             throw new InvalidOperationException(
-                $"[CHEFS] Could not extract a formId from request path: {path}"
+                $"[CHEFS] Request path is not an approved CHEFS form endpoint: {path}"
             );
 
         var formId = formIdMatch.Groups[1].Value;
@@ -77,5 +84,31 @@ public class ChefsApiKeyHandler : DelegatingHandler
         }
 
         return response;
+    }
+
+    /// <summary>
+    /// Prepends the base path segment from <see cref="ChefsOptions.BaseUrl"/> (e.g. "/app") to the
+    /// request URI when it is missing. Refit's absolute-path route templates otherwise strip it.
+    /// </summary>
+    private Uri? ApplyBasePath(Uri? requestUri)
+    {
+        if (requestUri is null || string.IsNullOrWhiteSpace(_options.BaseUrl))
+            return requestUri;
+
+        if (!Uri.TryCreate(_options.BaseUrl, UriKind.Absolute, out var baseUri))
+            return requestUri;
+
+        var basePath = baseUri.AbsolutePath.TrimEnd('/');
+        if (basePath.Length == 0)
+            return requestUri;
+
+        var currentPath = requestUri.AbsolutePath;
+        if (
+            currentPath.Equals(basePath, StringComparison.OrdinalIgnoreCase)
+            || currentPath.StartsWith(basePath + "/", StringComparison.OrdinalIgnoreCase)
+        )
+            return requestUri;
+
+        return new UriBuilder(requestUri) { Path = basePath + currentPath }.Uri;
     }
 }

--- a/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
+++ b/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
@@ -22,16 +22,18 @@ public static class ChefsServiceCollectionExtensions
         var section = configuration.GetSection(ChefsOptions.SectionName);
         services.Configure<ChefsOptions>(section);
 
-        var baseUrl = section["BaseUrl"];
-        var apiKey = section["ApiKey"];
+        ChefsOptions? chefsOptions = section.Exists() ? section.Get<ChefsOptions>() : null;
+
+        var baseUrl = chefsOptions?.BaseUrl;
+        var forms = chefsOptions?.Forms;
 
         if (string.IsNullOrWhiteSpace(baseUrl))
             throw new ConfigurationException(
                 "CHEFS API requires Chefs:BaseUrl (e.g. Chefs__BaseUrl in .env)."
             );
-        if (string.IsNullOrWhiteSpace(apiKey))
+        if (forms == null || forms.Count == 0)
             throw new ConfigurationException(
-                "CHEFS API requires Chefs:ApiKey (e.g. Chefs__ApiKey in .env)."
+                "CHEFS API requires Chefs:Forms (e.g. Chefs__Forms in .env)."
             );
 
         services.AddTransient<ChefsApiKeyHandler>();

--- a/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
+++ b/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ using Refit;
 namespace Probate.Api.Infrastructure.Chefs;
 
 /// <summary>
-/// Registers CHEFS API client and options. Fails at startup if BaseUrl or ApiKey are missing.
+/// Registers CHEFS API client and options. Fails at startup if BaseUrl or Forms are missing.
 /// Form ID is passed in per request from the controller (no default).
 /// </summary>
 public static class ChefsServiceCollectionExtensions

--- a/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
+++ b/api/Infrastructure/Chefs/ChefsServiceCollectionExtensions.cs
@@ -36,6 +36,24 @@ public static class ChefsServiceCollectionExtensions
                 "CHEFS API requires Chefs:Forms (e.g. Chefs__Forms in .env)."
             );
 
+        foreach (var (formKey, formOptions) in forms)
+        {
+            if (string.IsNullOrWhiteSpace(formKey))
+                throw new ConfigurationException(
+                    "CHEFS API requires each Chefs:Forms entry to have a non-empty logical key."
+                );
+
+            if (string.IsNullOrWhiteSpace(formOptions?.FormId))
+                throw new ConfigurationException(
+                    $"CHEFS API requires env variable Chefs:Forms:{formKey}:FormId (e.g. Chefs__Forms__{formKey}__FormId)."
+                );
+
+            if (string.IsNullOrWhiteSpace(formOptions.ApiKey))
+                throw new ConfigurationException(
+                    $"CHEFS API requires env variable Chefs:Forms:{formKey}:ApiKey (e.g. Chefs__Forms__{formKey}__ApiKey)."
+                );
+        }
+
         services.AddTransient<ChefsApiKeyHandler>();
         services
             .AddRefitClient<IChefsApi>()

--- a/api/Infrastructure/Chefs/IChefsApi.cs
+++ b/api/Infrastructure/Chefs/IChefsApi.cs
@@ -10,12 +10,12 @@ namespace Probate.Api.Infrastructure.Chefs;
 
 /// <summary>
 /// Refit client for the CHEFS (Common Hosted Form Service) API.
-/// We use form-id (per request) and api-key only; auth-token (JWT) is not used.
+/// The auth handler adds Basic Authentication from each form's configured API key.
 /// </summary>
 public interface IChefsApi
 {
     /// <summary>
-    /// Get submissions for a form. Sends form-id as path and header; api-key is added by ChefsApiKeyHandler.
+    /// Get submissions for a form. Sends form-id as path; authentication is added by ChefsApiKeyHandler.
     /// </summary>
     [Get("/api/v1/forms/{formId}/submissions")]
     Task<List<ChefsSubmissionSummary>> GetSubmissionsAsync(

--- a/api/Options/ChefsOptions.cs
+++ b/api/Options/ChefsOptions.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 
 namespace Probate.Api.Options;
 
+public class ChefsFormOptions
+{
+    public string FormId { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+}
+
 /// <summary>
 /// Configuration for the CHEFS (Common Hosted Form Service) API.
 /// API key is per form; bind from environment (e.g. Chefs__ApiKey, Chefs__BaseUrl).
@@ -16,12 +22,8 @@ public class ChefsOptions
     /// The GUID is never exposed to the frontend; callers use the logical key only.
     /// Example env var: Chefs__Forms__probate=&lt;guid&gt;
     /// </summary>
-    public Dictionary<string, string> Forms { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-
-    /// <summary>
-    /// API access key for the form. Required for CHEFS API calls (per-form).
-    /// </summary>
-    public string ApiKey { get; set; } = string.Empty;
+    public Dictionary<string, ChefsFormOptions> Forms { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// CHEFS API base URL. Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1

--- a/api/Options/ChefsOptions.cs
+++ b/api/Options/ChefsOptions.cs
@@ -11,16 +11,16 @@ public class ChefsFormOptions
 
 /// <summary>
 /// Configuration for the CHEFS (Common Hosted Form Service) API.
-/// API key is per form; bind from environment (e.g. Chefs__ApiKey, Chefs__BaseUrl).
+/// API keys are configured per form.
 /// </summary>
 public class ChefsOptions
 {
     public const string SectionName = "Chefs";
 
     /// <summary>
-    /// Maps logical form keys (sent by the frontend) to actual CHEFS form GUIDs.
+    /// Maps logical form keys (sent by the frontend) to actual CHEFS form configuration.
     /// The GUID is never exposed to the frontend; callers use the logical key only.
-    /// Example env var: Chefs__Forms__probate=&lt;guid&gt;
+    /// Example env vars: Chefs__Forms__probate__FormId and Chefs__Forms__probate__ApiKey.
     /// </summary>
     public Dictionary<string, ChefsFormOptions> Forms { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);

--- a/api/Options/ChefsOptions.cs
+++ b/api/Options/ChefsOptions.cs
@@ -26,7 +26,7 @@ public class ChefsOptions
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// CHEFS API base URL. Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1
+    /// CHEFS app base URL. Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app
     /// (Form submit URL is same host: /app/form/submit?f={formId}).
     /// </summary>
     public string BaseUrl { get; set; } = string.Empty;

--- a/api/Services/ChefsApplicationService.cs
+++ b/api/Services/ChefsApplicationService.cs
@@ -40,8 +40,8 @@ public class ChefsApplicationService : IChefsApplicationService
     )
     {
         if (
-            !_options.Forms.TryGetValue(formKey, out var formGuid)
-            || string.IsNullOrWhiteSpace(formGuid)
+            !_options.Forms.TryGetValue(formKey, out var formOptions)
+            || string.IsNullOrWhiteSpace(formOptions?.FormId)
         )
             throw new InvalidOperationException($"Form key '{formKey}' is not configured.");
 
@@ -53,7 +53,7 @@ public class ChefsApplicationService : IChefsApplicationService
         List<ChefsSubmissionSummary> response;
         try
         {
-            response = await _chefsApi.GetSubmissionsAsync(formGuid, cancellationToken);
+            response = await _chefsApi.GetSubmissionsAsync(formOptions.FormId, cancellationToken);
         }
         catch (ApiException ex)
         {
@@ -116,8 +116,8 @@ public class ChefsApplicationService : IChefsApplicationService
     )
     {
         if (
-            !_options.Forms.TryGetValue(formKey, out var formGuid)
-            || string.IsNullOrWhiteSpace(formGuid)
+            !_options.Forms.TryGetValue(formKey, out var formOptions)
+            || string.IsNullOrWhiteSpace(formOptions?.FormId)
         )
             throw new InvalidOperationException($"Form key '{formKey}' is not configured.");
 
@@ -130,8 +130,8 @@ public class ChefsApplicationService : IChefsApplicationService
         try
         {
             response = await _chefsApi.GetAuthTokenAsync(
-                formGuid,
-                new ChefsAuthTokenRequest { FormId = formGuid },
+                formOptions.FormId,
+                new ChefsAuthTokenRequest { FormId = formOptions.FormId },
                 cancellationToken
             );
         }
@@ -176,7 +176,7 @@ public class ChefsApplicationService : IChefsApplicationService
         return new ChefsAuthTokenDto
         {
             Token = response.Token,
-            FormId = formGuid,
+            FormId = formOptions.FormId,
             BaseUrl = _options.BaseUrl.TrimEnd('/'),
         };
     }

--- a/api/Services/SubmissionService.cs
+++ b/api/Services/SubmissionService.cs
@@ -177,7 +177,11 @@ namespace Probate.Api.Services
             await _db.SaveChangesAsync(cancellationToken);
 
             // Then delete from CHEFS — get formId from options
-            if (!_options.Forms.TryGetValue("legal", out var formOptions))
+            // TODO step based forms will need to handle multiple form ids.
+            if (
+                !_options.Forms.TryGetValue("legal", out var formOptions)
+                || string.IsNullOrWhiteSpace(formOptions?.FormId)
+            )
                 throw new InvalidOperationException("Form key 'legal' is not configured.");
 
             try

--- a/api/Services/SubmissionService.cs
+++ b/api/Services/SubmissionService.cs
@@ -177,13 +177,13 @@ namespace Probate.Api.Services
             await _db.SaveChangesAsync(cancellationToken);
 
             // Then delete from CHEFS — get formId from options
-            if (!_options.Forms.TryGetValue("legal", out var formGuid))
+            if (!_options.Forms.TryGetValue("legal", out var formOptions))
                 throw new InvalidOperationException("Form key 'legal' is not configured.");
 
             try
             {
                 await _chefsApi.DeleteSubmissionAsync(
-                    formGuid,
+                    formOptions.FormId,
                     submission.ChefsSubmissionId,
                     cancellationToken
                 );

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -25,9 +25,9 @@
     "BaseUrl": "[CHEFS_BASE_URL]",
     "Forms": {
       "legal": {
-        "FormId": "[CHEFS_FORM_LEGAL_ID]",
+        "FormId": "[CHEFS_FORM_LEGAL_FORMID]",
         "ApiKey": "[CHEFS_FORM_LEGAL_API_KEY]"
-      },
+      }
       "nonlegal": {
         "FormId": "[CHEFS_FORM_NONLEGAL_ID]",
         "ApiKey": "[CHEFS_FORM_NONLEGAL_API_KEY]"

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -27,7 +27,7 @@
       "legal": {
         "FormId": "[CHEFS_FORM_LEGAL_FORMID]",
         "ApiKey": "[CHEFS_FORM_LEGAL_API_KEY]"
-      }
+      },
       "nonlegal": {
         "FormId": "[CHEFS_FORM_NONLEGAL_FORMID]",
         "ApiKey": "[CHEFS_FORM_NONLEGAL_API_KEY]"

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -23,7 +23,6 @@
   },
   "Chefs": {
     "BaseUrl": "[CHEFS_BASE_URL]",
-    "ApiKey": "[CHEFS_API_KEY]",
     "Forms": {
       "legal": {
         "FormId": "[CHEFS_FORM_LEGAL_ID]",

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -29,7 +29,7 @@
         "ApiKey": "[CHEFS_FORM_LEGAL_API_KEY]"
       }
       "nonlegal": {
-        "FormId": "[CHEFS_FORM_NONLEGAL_ID]",
+        "FormId": "[CHEFS_FORM_NONLEGAL_FORMID]",
         "ApiKey": "[CHEFS_FORM_NONLEGAL_API_KEY]"
       }
     }

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -25,8 +25,14 @@
     "BaseUrl": "[CHEFS_BASE_URL]",
     "ApiKey": "[CHEFS_API_KEY]",
     "Forms": {
-      "legal": "[CHEFS_FORM_LEGAL_ID]",
-      "nonlegal": "[CHEFS_FORM_NONLEGAL_ID]"
+      "legal": {
+        "FormId": "[CHEFS_FORM_LEGAL_ID]",
+        "ApiKey": "[CHEFS_FORM_LEGAL_API_KEY]"
+      },
+      "nonlegal": {
+        "FormId": "[CHEFS_FORM_NONLEGAL_ID]",
+        "ApiKey": "[CHEFS_FORM_NONLEGAL_API_KEY]"
+      }
     }
   },
   "CDogs": {

--- a/docker/.env.template
+++ b/docker/.env.template
@@ -28,7 +28,6 @@ OIDC_RP_REFRESH_THRESHOLD=00:05:00
 
 # CHEFS (Common Hosted Form Service) - API key is per form
 # Form URL example: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/form/submit?f={formId}
-COMPOSE_PROJECT_NAME=jag-probate
 CHEFS_FORM_LEGAL_FORMID=
 CHEFS_FORM_LEGAL_API_KEY=
 CHEFS_FORM_NONLEGAL_FORMID=

--- a/docker/.env.template
+++ b/docker/.env.template
@@ -28,9 +28,11 @@ OIDC_RP_REFRESH_THRESHOLD=00:05:00
 
 # CHEFS (Common Hosted Form Service) - API key is per form
 # Form URL example: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/form/submit?f={formId}
-CHEFS_FORM_ID_NONLEGAL=
-CHEFS_FORM_ID_LEGAL=
-CHEFS_API_KEY=
+COMPOSE_PROJECT_NAME=jag-probate
+CHEFS_FORM_LEGAL_FORMID=
+CHEFS_FORM_LEGAL_API_KEY=
+CHEFS_FORM_NONLEGAL_FORMID=
+CHEFS_FORM_NONLEGAL_API_KEY=
 # Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1
 CHEFS_BASE_URL=
 

--- a/docker/.env.template
+++ b/docker/.env.template
@@ -33,7 +33,7 @@ CHEFS_FORM_LEGAL_FORMID=
 CHEFS_FORM_LEGAL_API_KEY=
 CHEFS_FORM_NONLEGAL_FORMID=
 CHEFS_FORM_NONLEGAL_API_KEY=
-# Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1
+# Dev: https://chefs-dev.apps.silver.devops.gov.bc.ca/app
 CHEFS_BASE_URL=
 
 CDOGS_BASE_URL=https://cdogs-test.api.gov.bc.ca/api/v2

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: "${COMPOSE_PROJECT_NAME}-web"
+    image: '${COMPOSE_PROJECT_NAME}-web'
     environment:
       - API_URL=${API_URL:-http://api:5000}
       - WEB_BASE_HREF=${WEB_BASE_HREF:-/probate/}
@@ -12,9 +12,9 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - VITE_CHEFS_BASE_URL=${CHEFS_BASE_URL}
     ports:
-      - "8080:8080"
+      - '8080:8080'
     volumes:
-      - "${LOCAL_WORKSPACE_FOLDER-..}/web/src:/opt/app-root/src/src"
+      - '${LOCAL_WORKSPACE_FOLDER-..}/web/src:/opt/app-root/src/src'
       - "${LOCAL_WORKSPACE_FOLDER-..}/web/package.json:/opt/app-root/src/packag\
         e.json"
       - "${LOCAL_WORKSPACE_FOLDER-..}/web/vite.config.js:/opt/app-root/src/vite\
@@ -27,7 +27,7 @@ services:
       - api
 
   api:
-    image: "${COMPOSE_PROJECT_NAME}-api"
+    image: '${COMPOSE_PROJECT_NAME}-api'
     environment:
       - ASPNETCORE_URLS=${ASPNETCORE_URLS}
       - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}
@@ -39,9 +39,10 @@ services:
       - Keycloak__KcIdpHint=${OIDC_RP_KC_IDP_HINT}
       - Keycloak__RefreshThreshold=${OIDC_RP_REFRESH_THRESHOLD:-00:05:00}
       - TokenRefreshThreshold=${TOKEN_REFRESH_THRESHOLD}
-      - Chefs__Forms__legal=${CHEFS_FORM_ID_LEGAL}
-      - Chefs__Forms__nonlegal=${CHEFS_FORM_ID_NONLEGAL}
-      - Chefs__ApiKey=${CHEFS_API_KEY}
+      - Chefs__Forms__legal__FormId=${CHEFS_FORM_LEGAL_FORMID}
+      - Chefs__Forms__legal__ApiKey=${CHEFS_FORM_LEGAL_API_KEY}
+      - Chefs__Forms__nonlegal__FormId=${CHEFS_FORM_NONLEGAL_FORMID}
+      - Chefs__Forms__nonlegal__ApiKey=${CHEFS_FORM_NONLEGAL_API_KEY}
       - Chefs__BaseUrl=${CHEFS_BASE_URL}
       - CDogs__BaseUrl=${CDOGS_BASE_URL}
       - CDogs__TokenUrl=${CDOGS_TOKEN_URL}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: '${COMPOSE_PROJECT_NAME}-web'
+    image: "${COMPOSE_PROJECT_NAME}-web"
     environment:
       - API_URL=${API_URL:-http://api:5000}
       - WEB_BASE_HREF=${WEB_BASE_HREF:-/probate/}
@@ -12,9 +12,9 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - VITE_CHEFS_BASE_URL=${CHEFS_BASE_URL}
     ports:
-      - '8080:8080'
+      - "8080:8080"
     volumes:
-      - '${LOCAL_WORKSPACE_FOLDER-..}/web/src:/opt/app-root/src/src'
+      - "${LOCAL_WORKSPACE_FOLDER-..}/web/src:/opt/app-root/src/src"
       - "${LOCAL_WORKSPACE_FOLDER-..}/web/package.json:/opt/app-root/src/packag\
         e.json"
       - "${LOCAL_WORKSPACE_FOLDER-..}/web/vite.config.js:/opt/app-root/src/vite\
@@ -27,7 +27,7 @@ services:
       - api
 
   api:
-    image: '${COMPOSE_PROJECT_NAME}-api'
+    image: "${COMPOSE_PROJECT_NAME}-api"
     environment:
       - ASPNETCORE_URLS=${ASPNETCORE_URLS}
       - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}

--- a/docs/chefs.md
+++ b/docs/chefs.md
@@ -1,6 +1,6 @@
 # CHEFS Integration
 
-The API integrates with [CHEFS (Common Hosted Form Service)](https://developer.gov.bc.ca/docs/default/component/chefs-techdocs/) to retrieve form submissions (applications) for the dashboard. Authentication uses **api-key** only (no auth-token).
+The API integrates with [CHEFS (Common Hosted Form Service)](https://developer.gov.bc.ca/docs/default/component/chefs-techdocs/) to retrieve form submissions (applications) for the dashboard. CHEFS credentials are configured per form; the API sends Basic Authentication using the form GUID and that form's API key.
 
 ## Endpoint
 
@@ -19,16 +19,17 @@ Copy `docker/.env.template` to `docker/.env` and set the following variables:
 | Variable | Description |
 |---|---|
 | `Chefs__BaseUrl` | CHEFS API base URL (e.g. `https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1`) |
-| `Chefs__ApiKey` | API key for the form (obtain from CHEFS form settings) |
-| `Chefs__Forms__<key>` | Maps a logical form key to its CHEFS form GUID. Add one entry per form. |
+| `Chefs__Forms__<key>__FormId` | Maps a logical form key to its CHEFS form GUID. Add one entry per form. |
+| `Chefs__Forms__<key>__ApiKey` | API key for that CHEFS form. Add one entry per form. |
 
 ### Example: two forms
 
 ```
 Chefs__BaseUrl=https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1
-Chefs__ApiKey=your-api-key
-Chefs__Forms__legal=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-Chefs__Forms__non-legal=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+Chefs__Forms__legal__FormId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+Chefs__Forms__legal__ApiKey=legal-api-key
+Chefs__Forms__nonlegal__FormId=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+Chefs__Forms__nonlegal__ApiKey=nonlegal-api-key
 ```
 
-The frontend calls `?formKey=legal` or `?formKey=non-legal`. Form GUIDs remain server-side only.
+The frontend calls `?formKey=legal` or `?formKey=nonlegal`. Form GUIDs and API keys remain server-side only.

--- a/docs/chefs.md
+++ b/docs/chefs.md
@@ -12,24 +12,33 @@ Returns current and previous applications (submissions) for the given form. Requ
 
 **Error handling:** CHEFS API errors (4xx/5xx or unreachable) are returned as Problem Details (e.g. `502 Bad Gateway` with a descriptive message).
 
-## Configuration
+## Configuration (DEV Environments)
 
-Copy `docker/.env.template` to `docker/.env` and set the following variables:
+Copy `docker/.env.template` to `docker/.env` and set the following variables. `docker-compose.yaml` maps these flat `.env` values onto the ASP.NET Core `Chefs__*` configuration keys for the `api` service.
 
-| Variable | Description |
-|---|---|
-| `Chefs__BaseUrl` | CHEFS app base URL (e.g. `https://chefs-dev.apps.silver.devops.gov.bc.ca/app`) |
-| `Chefs__Forms__<key>__FormId` | Maps a logical form key to its CHEFS form GUID. Add one entry per form. |
-| `Chefs__Forms__<key>__ApiKey` | API key for that CHEFS form. Add one entry per form. |
+| `.env` variable               | Maps to config key               | Description                                                                    |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------------------------------ |
+| `CHEFS_BASE_URL`              | `Chefs__BaseUrl`                 | CHEFS app base URL (e.g. `https://chefs-dev.apps.silver.devops.gov.bc.ca/app`) |
+| `CHEFS_FORM_LEGAL_FORMID`     | `Chefs__Forms__legal__FormId`    | CHEFS form GUID for the `legal` form key.                                      |
+| `CHEFS_FORM_LEGAL_API_KEY`    | `Chefs__Forms__legal__ApiKey`    | API key for the `legal` form.                                                  |
+| `CHEFS_FORM_NONLEGAL_FORMID`  | `Chefs__Forms__nonlegal__FormId` | CHEFS form GUID for the `nonlegal` form key.                                   |
+| `CHEFS_FORM_NONLEGAL_API_KEY` | `Chefs__Forms__nonlegal__ApiKey` | API key for the `nonlegal` form.                                               |
 
-### Example: two forms
+### Example
 
 ```
-Chefs__BaseUrl=https://chefs-dev.apps.silver.devops.gov.bc.ca/app
-Chefs__Forms__legal__FormId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-Chefs__Forms__legal__ApiKey=legal-api-key
-Chefs__Forms__nonlegal__FormId=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
-Chefs__Forms__nonlegal__ApiKey=nonlegal-api-key
+CHEFS_BASE_URL=https://chefs-dev.apps.silver.devops.gov.bc.ca/app
+CHEFS_FORM_LEGAL_FORMID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+CHEFS_FORM_LEGAL_API_KEY=legal-api-key
+CHEFS_FORM_NONLEGAL_FORMID=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+CHEFS_FORM_NONLEGAL_API_KEY=nonlegal-api-key
 ```
 
 The frontend calls `?formKey=legal` or `?formKey=nonlegal`. Form GUIDs and API keys remain server-side only.
+
+### Adding a new form
+
+The `legal`/`nonlegal` keys are hardcoded in the `api` service's `environment` block in [docker/docker-compose.yaml](../docker/docker-compose.yaml). To add another form:
+
+1. Add `CHEFS_FORM_<KEY>_FORMID` and `CHEFS_FORM_<KEY>_API_KEY` to `docker/.env.template` and `docker/.env`.
+2. Add a corresponding `Chefs__Forms__<key>__FormId` / `Chefs__Forms__<key>__ApiKey` entry to the `api` service's `environment` list in `docker/docker-compose.yaml`.

--- a/docs/chefs.md
+++ b/docs/chefs.md
@@ -18,14 +18,14 @@ Copy `docker/.env.template` to `docker/.env` and set the following variables:
 
 | Variable | Description |
 |---|---|
-| `Chefs__BaseUrl` | CHEFS API base URL (e.g. `https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1`) |
+| `Chefs__BaseUrl` | CHEFS app base URL (e.g. `https://chefs-dev.apps.silver.devops.gov.bc.ca/app`) |
 | `Chefs__Forms__<key>__FormId` | Maps a logical form key to its CHEFS form GUID. Add one entry per form. |
 | `Chefs__Forms__<key>__ApiKey` | API key for that CHEFS form. Add one entry per form. |
 
 ### Example: two forms
 
 ```
-Chefs__BaseUrl=https://chefs-dev.apps.silver.devops.gov.bc.ca/app/api/v1
+Chefs__BaseUrl=https://chefs-dev.apps.silver.devops.gov.bc.ca/app
 Chefs__Forms__legal__FormId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 Chefs__Forms__legal__ApiKey=legal-api-key
 Chefs__Forms__nonlegal__FormId=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy

--- a/docs/chefs.md
+++ b/docs/chefs.md
@@ -36,6 +36,8 @@ CHEFS_FORM_NONLEGAL_API_KEY=nonlegal-api-key
 
 The frontend calls `?formKey=legal` or `?formKey=nonlegal`. Form GUIDs and API keys remain server-side only.
 
+CHEFS credentials are attached only to approved outbound form endpoints (`/app/api/v1/forms/{formId}/...` and `/app/gateway/v1/auth/token/forms/{formId}`). Other CHEFS paths are rejected instead of being sent with credentials.
+
 ### Adding a new form
 
 The `legal`/`nonlegal` keys are hardcoded in the `api` service's `environment` block in [docker/docker-compose.yaml](../docker/docker-compose.yaml). To add another form:


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[REPGRANT-618](https://jira.justice.gov.bc.ca/browse/REPGRANT-618)**----  

## Description

1. Change format of Form and API Key structure in configuration.
2. Update API Token handling and Refit API key handling.
3. I chose to maintain the friendly name wrapping to keep the integrations flexible.
    ```Json
    {
      "FriendlyName": { FormID: "GUID-STRING-HERE", ApiKey: "Some-Key-Here"}, 
    }
    ```

### AI Summary 

This pull request refactors how CHEFS API keys and form IDs are managed and applied throughout the backend service. The main improvement is to support per-form API keys, which are now configured and used dynamically based on the form referenced in each request. This involves changes to configuration structures, authentication handling, and related service logic. Additionally, there are minor updates to Docker Compose formatting.

**CHEFS API per-form key support and related refactoring:**

* Updated the `ChefsOptions` configuration to store a dictionary of `ChefsFormOptions` objects (containing both `FormId` and `ApiKey`), instead of a dictionary of form GUID strings. This enables per-form API key support. (`api/Options/ChefsOptions.cs`, `api/appsettings.json`, `docker/docker-compose.yaml`) [[1]](diffhunk://#diff-5578cc468af506adb9835efd838fdcd330ec56fc08e7f735fc289046a2bd907fL19-R26) [[2]](diffhunk://#diff-d0c36366961d40707888ff5f9edaa26e55d90bd9d2742a6e5e3d51e1dc3e0bf2L28-R35) [[3]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L42-R45)
* Refactored `ChefsApiKeyHandler` to extract the form GUID from the request path using a regular expression, then look up the correct API key for that form and apply Basic Authentication. Removed fallback logic for a single global API key. (`api/Infrastructure/Chefs/ChefsApiKeyHandler.cs`) [[1]](diffhunk://#diff-32624b57c0ce3d1f946371a29efc45d0db78c7341aca24b0dd5ee997f661ffc2L13-R17) [[2]](diffhunk://#diff-32624b57c0ce3d1f946371a29efc45d0db78c7341aca24b0dd5ee997f661ffc2L33-L89)
* Updated all usages of the CHEFS form configuration in service classes to reference the new `ChefsFormOptions` structure, ensuring the correct form ID and API key are used for each operation. (`api/Services/ChefsApplicationService.cs`, `api/Services/SubmissionService.cs`) [[1]](diffhunk://#diff-92305465664f6195a40145175272bf12e2b2d1d5c57f69ad3feeb457005bb8b5L43-R44) [[2]](diffhunk://#diff-92305465664f6195a40145175272bf12e2b2d1d5c57f69ad3feeb457005bb8b5L56-R56) [[3]](diffhunk://#diff-92305465664f6195a40145175272bf12e2b2d1d5c57f69ad3feeb457005bb8b5L119-R120) [[4]](diffhunk://#diff-92305465664f6195a40145175272bf12e2b2d1d5c57f69ad3feeb457005bb8b5L133-R134) [[5]](diffhunk://#diff-92305465664f6195a40145175272bf12e2b2d1d5c57f69ad3feeb457005bb8b5L179-R179) [[6]](diffhunk://#diff-1b9cfae6c9fccb07d7eb943ddb19f8c8ae4970547d43069b35e23e2a717a94b6L180-R186)

**Configuration and deployment updates:**

* Updated `appsettings.json` and Docker Compose environment variable mapping to support the new per-form configuration structure. (`api/appsettings.json`, `docker/docker-compose.yaml`) [[1]](diffhunk://#diff-d0c36366961d40707888ff5f9edaa26e55d90bd9d2742a6e5e3d51e1dc3e0bf2L28-R35) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L42-R45)
* Minor formatting changes to `docker-compose.yaml` for consistency (switching from double to single quotes). (`docker/docker-compose.yaml`) [[1]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L3-R3) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L15-R17) [[3]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L30-R30)

These changes ensure that each CHEFS form can be configured with its own API key, improving security and flexibility when integrating with the CHEFS service.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
- [X] Local dev instance (include screenshot)

### Screenshots

Regression test performed
<img width="2166" height="634" alt="image" src="https://github.com/user-attachments/assets/0ef16614-f17d-4a46-893e-06a4de03912f" />

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings (csharpier, eslint, etc.)
- [X] New and existing tests (unit, e2e, integration, etc.) pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules